### PR TITLE
feat(build): Support building multiple architectures via Docker buildx

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,17 +9,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - 
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2.4.2
-      -
-        name: Login to Docker Hub
+
+      - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PAT }}
-      -
-        name: Build & push Docker image
+
+      - name: Preapre new buildx context
+        run: docker buildx create --use
+
+      - name: Build & push Docker image
         run: |
-          make build
-          make push
+          make build-and-push

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,8 @@ clean: clean-kubebuilder
 clean-kubebuilder:
 	rm -Rf _test/kubebuilder
 
-build:
-	docker build -t "$(IMAGE_NAME):$(IMAGE_TAG)" .
-
-push:
-	docker push "$(IMAGE_NAME):$(IMAGE_TAG)"
+build-and-push:
+	docker buildx build --platform linux/arm/v7,linux/amd64 -t $(IMAGE_NAME):$(IMAGE_TAG) . --push
 
 .PHONY: rendered-manifest.yaml
 rendered-manifest.yaml:


### PR DESCRIPTION
Hey,

I did find your webhook integration for netcup while setting up cert-manager in my local cluster.

However, since my cluster is running on an Raspberry Pi 4 and hence on arm architecture, I couldn't use your implementation because the Docker image was only build for amd64.

I've tweaked the build process a little bit in order to be compatible with multiple architectures.

As you can see, I only added support for arm/v7, you might want to extend the `--platform` argument for other architectures, too.

You can see my test image here: https://hub.docker.com/r/tibuntu/cert-manager-webhook-netcup/tags

Best regards!