### PR TITLE
fix: match host exactly

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"regexp"
 	"strconv"
-	"strings"
 
 	netcup "github.com/aellwein/netcup-dns-api/pkg/v1"
 	extapi "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -159,7 +158,7 @@ func addOrDeleteTxtRecord(cfg *netcupClientConfig, resolvedFqdn string, key stri
 	var foundRec *netcup.DnsRecord
 	for _, rec := range *recs {
 		// record already exists?
-		if strings.HasPrefix(host, rec.Hostname) && rec.Type == "TXT" {
+		if host == rec.Hostname && rec.Type == "TXT" {
 			foundRec = &rec
 			break
 		}


### PR DESCRIPTION
This PR changes matches the host exactly when looking for an existing record for the same host (instead of using a prefix matching). 

This fixes an issue where a challenge which is supposed create a `_acme-challenge.subdomain.` record overwrites an existing `_acme-challenge.` TXT record (note the missing subdomain) . This especially happens when issuing a cert for both domain.com and subdomain.domain.com and the challenge for domain.com happens to be created first.
 This causes the certificate issuance to fail silently because it kept waiting for DNS propagation of a DNS record which was never set.

I'm not sure why prefix matching was used and whether exact matching could lead to problems in some cases, but in my limited testing it always worked. An image with this change is available at `ghcr.io/romano21a/cert-manager-webhook-netcup:develop`