### PR TITLE
add securityContext

### DIFF
--- a/deploy/cert-manager-webhook-netcup/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-netcup/templates/deployment.yaml
@@ -21,10 +21,14 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ include "cert-manager-webhook-netcup.fullname" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ include "cert-manager-webhook-netcup.fullImageName" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           args:
             - --tls-cert-file=/tls/tls.crt
             - --tls-private-key-file=/tls/tls.key

--- a/deploy/cert-manager-webhook-netcup/values.yaml
+++ b/deploy/cert-manager-webhook-netcup/values.yaml
@@ -24,6 +24,21 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
+podSecurityContext:
+  runAsUser: 10001
+  runAsGroup: 10001
+  fsGroup: 10002
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+  capabilities:
+    drop:
+      - ALL
+
 service:
   type: ClusterIP
   port: 443


### PR DESCRIPTION
Add securityContext with defaults to run the container as non-root.
With the added configuration the deployment is permitted in a restricted namespace.

Hello @aellwein,
is it possible to additionally set `readOnlyRootFilesystem: true` or is filesystem write access needed?

And thanks for creating this webhook - works perfectly!